### PR TITLE
Update "http-proxy-middleware" dependency to ">=2.0.9".

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17587,7 +17587,7 @@
         "express": "^4.17.3",
         "graceful-fs": "^4.2.6",
         "html-entities": "^2.3.2",
-        "http-proxy-middleware": "^2.0.3",
+        "http-proxy-middleware": ">=2.0.9",
         "ipaddr.js": "^2.0.1",
         "launch-editor": "^2.6.0",
         "open": "^8.0.9",


### PR DESCRIPTION
It fixes the following warnings:

1. In http-proxy-middleware before 2.0.8 and 3.x before 3.0.4, writeBody can be called twice because "else if" is not used.

2. In http-proxy-middleware before 2.0.9 and 3.x before 3.0.5, fixRequestBody proceeds even if bodyParser has failed.